### PR TITLE
Disable AndroidX since it is not yet supported by react-native

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,7 @@
+# We need to override this because the react-native libraries have not been migrated
+# to AndroidX yet. We are using the support annotation lib as a dependency and we don't
+# want it to be jetified.
+# We will probably be able to remove this after react-native 0.60.x is released.
+
+android.useAndroidX=false
+android.enableJetifier=false


### PR DESCRIPTION
Since react-native libraries have not yet been migrated to AndroidX, we need to disable the support annotation library from being jetified when the main project is using AndroidX.

This can probably be removed after react-native 0.60.x is released.