### PR TITLE
Dispose transfer listener when the playback stops

### DIFF
--- a/android/src/main/java/com/perrystreetsoftware/RNRtmpView.java
+++ b/android/src/main/java/com/perrystreetsoftware/RNRtmpView.java
@@ -270,6 +270,11 @@ public class RNRtmpView extends FrameLayout implements LifecycleEventListener, R
         if (this.mPlayer != null) {
             mPlayer.stop();
         }
+
+        if (this.mTransferListener != null) {
+            this.mTransferListener.dispose();
+            this.mTransferListener = null;
+        }
     }
 
     public void setPlayOnResume(boolean value) {


### PR DESCRIPTION
This fixes the issue where the transfer listener would still emit events even when the view is destroyed because we never dispose it. We now dispose it in `stop()` which is being called when the activity / fragment is paused (if the `getPauseOnStop()` is `true`). `stop()` is also being called in `cleanupMediaPlayerResources()` which is triggered when the activity / fragment is destroyed.

The transfer listener is being re-created every time we call `play()` so it's fine if we dispose it in `stop()`.